### PR TITLE
Updating default fill styles - previous values were incorrect

### DIFF
--- a/xlsx.js
+++ b/xlsx.js
@@ -12106,14 +12106,14 @@ var XmlNode = (function () {
         if (!defaultStyle.font) defaultStyle.font = {name: 'Calibri', sz: '12'};
         if (!defaultStyle.font.name) defaultStyle.font.name = 'Calibri';
         if (!defaultStyle.font.sz) defaultStyle.font.sz = 11;
-        if (!defaultStyle.fill) defaultStyle.fill = { fgColor: { patternType: "none"}};
+        if (!defaultStyle.fill) defaultStyle.fill = {patternType: "none"};
         if (!defaultStyle.border) defaultStyle.border = {};
         if (!defaultStyle.numFmt) defaultStyle.numFmt = 0;
 
         this.defaultStyle = defaultStyle;
 
         var gray125Style = JSON.parse(JSON.stringify(defaultStyle));
-        gray125Style.fill = { fgColor: { patternType: "gray125"}}
+        gray125Style.fill = {patternType: "gray125"};
 
         this.addStyles([defaultStyle, gray125Style]);
         return this;


### PR DESCRIPTION
Previous values resulted in a styles.xml with:
```
  <fills count="2">
    <fill>
      <patternFill patternType="solid">
        <bgColor/>
      </patternFill>
    </fill>
    <fill>
      <patternFill patternType="solid">
        <bgColor/>
      </patternFill>
    </fill>
  </fills>
```
instead of the expected:
```
 <fills count="2">
    <fill>
      <patternFill patternType="none"/>
    </fill>
    <fill>
      <patternFill patternType="gray125"/>
    </fill>
  </fills>
```