### PR TITLE
Breaks references in style objects

### DIFF
--- a/bits/66_wscommon.js
+++ b/bits/66_wscommon.js
@@ -56,7 +56,7 @@ function get_cell_style_csf(cellXf) {
     }
 
 
-    return s;
+    return JSON.parse(JSON.stringify(s));
   }
   return null;
 }

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
 		"commander":""
 	},
 	"devDependencies": {
+		"cheerio":"^0.19.0",
 		"mocha":"",
 		"xlsjs":"",
 		"uglify-js":""

--- a/tests/test-style.js
+++ b/tests/test-style.js
@@ -690,5 +690,26 @@ describe("Export styles", function () {
     assert(basicallyEquals(workbook.Sheets.Main,wb2.Sheets.Main));
   });
 
+  it('should edit style of one cell without applie modification on other cell', function () {
+    var wb2 = XLSX.read(XLSX.write(workbook, {type:"buffer", bookType: 'xlsx'}), {cellStyles: true, cellNF: true})
+
+    var A6s = wb2.Sheets.Main.A6.s;
+    var B6s = wb2.Sheets.Main.B6.s;
+
+    Object.keys(A6s).forEach(function(key) {
+      if(A6s[key])
+        assert(A6s[key] !== B6s[key]);
+    });
+
+    assert(A6s.border.top === undefined);
+    assert(B6s.border.top === undefined);
+
+    A6s.border.top = {};
+    assert(B6s.border.top === undefined);
+
+    XLSX.writeFile(wb2, '/tmp/wb2.xlsx',  { defaultCellStyle: defaultCellStyle });
+    assert(basicallyEquals(workbook.Sheets.Main,wb2.Sheets.Main));
+  });
+
 });
 

--- a/xlsx.js
+++ b/xlsx.js
@@ -7497,7 +7497,7 @@ function get_cell_style_csf(cellXf) {
     }
 
 
-    return s;
+    return JSON.parse(JSON.stringify(s));
   }
   return null;
 }


### PR DESCRIPTION
On load a workbook, all cells without style are are set with default value. Unfortunately, they shared the same object reference. 