### PR TITLE
FIX cell formulas not working for writing Workbook

### DIFF
--- a/xlsx.js
+++ b/xlsx.js
@@ -7651,7 +7651,7 @@ function write_ws_xml_cols(ws, cols) {
 }
 
 function write_ws_xml_cell(cell, ref, ws, opts, idx, wb) {
-	if(cell.v === undefined && cell.s === undefined) return "";
+	if ( ! (cell.v || cell.s ||  cell.f ) ) return "";
 	var vv = "";
 	var oldt = cell.t, oldv = cell.v;
 	switch(cell.t) {
@@ -7668,7 +7668,9 @@ function write_ws_xml_cell(cell, ref, ws, opts, idx, wb) {
 			break;
 		default: vv = cell.v; break;
 	}
-	var v = writetag('v', escapexml(vv)), o = {r:ref};
+	var o = { r: ref };
+	var v = cell.f ? writetag('f', escapexml(cell.f)) : writetag('v', escapexml(vv));
+	
 	/* TODO: cell style */
 	var os = get_cell_style(opts.cellXfs, cell, opts);
 	if(os !== 0) o.s = os;


### PR DESCRIPTION
There is an issue when trying to write cell with `f attribute (formula)` that the cell got ignored and not written in the output file as expected