### PR TITLE
Adding sheetFormatPr for better compat with macos preview

### DIFF
--- a/bits/67_wsxml.js
+++ b/bits/67_wsxml.js
@@ -314,6 +314,10 @@ function write_ws_xml(idx, opts, wb) {
   });
   o[o.length] = writextag('sheetViews', sheetView);
 
+  o[o.length] = writextag('sheetFormatPr', null, {
+    defaultRowHeight: (opts.sheetFormat && opts.sheetFormat.defaultRowHeight) || '13.5',
+  });
+
 	if(ws['!cols'] !== undefined && ws['!cols'].length > 0) o[o.length] = (write_ws_xml_cols(ws, ws['!cols']));
 	o[sidx = o.length] = '<sheetData/>';
 	if(ws['!ref'] !== undefined) {

--- a/xlsx.js
+++ b/xlsx.js
@@ -7846,6 +7846,10 @@ function write_ws_xml(idx, opts, wb) {
   });
   o[o.length] = writextag('sheetViews', sheetView);
 
+  o[o.length] = writextag('sheetFormatPr', null, {
+    defaultRowHeight: (opts.sheetFormat && opts.sheetFormat.defaultRowHeight) || '13.5',
+  });
+
 	if(ws['!cols'] !== undefined && ws['!cols'].length > 0) o[o.length] = (write_ws_xml_cols(ws, ws['!cols']));
 	o[sidx = o.length] = '<sheetData/>';
 	if(ws['!ref'] !== undefined) {


### PR DESCRIPTION
This fixes ios and macos preview of spreadsheets created with xlsx-style.
