### PR TITLE
Skip cells with incorrect link to shared strings

### DIFF
--- a/xlsx.js
+++ b/xlsx.js
@@ -7770,6 +7770,7 @@ return function parse_ws_xml_data(sdata, s, opts, guess) {
           if(isNaN(p.v)) p.v = "" // we don't want NaN if p.v is null
           break;
 				case 's':
+          if (!p.hasOwnProperty('v')) continue;
 					sstr = strs[parseInt(p.v, 10)];
 					p.v = sstr.t;
 					p.r = sstr.r;


### PR DESCRIPTION
Hello.

I'm trying to parse a XLSX file, but the parser does not parse sheet's data. I see workbook, i see sheet's name, but 'sheets' field is empty.

I did a research and found that 'parse_ws_xml_data' generates exception:
```
        /* 18.18.11 t ST_CellType */
        switch(p.t) {
          case 'n': p.v = parseFloat(p.v); break;
          case 's':
            sstr = strs[parseInt(p.v, 10)];                                                                                         
            p.v = sstr.t;
            p.r = sstr.r;
            if(opts.cellHTML) p.h = sstr.h;
            break;
```

exception on line 7495, because sstr is undefined, because 'p' contains only 't'.

I did a research of my file the cell (A1) that is causes exception has the following structure:

```
<row r="1" spans="1:9" customHeight="1" ht="35"><c r="A1" t="s"/><c r="B1" s="14" t="s"><v>0</v></c><c r="C1" s="1"/><c r="D1" s="1"/><c r="E1" s="1"/><c r="F1" s="1"/><c r="G1" s="1"/><c r="H1" s="1"/><c r="I1" s="1"/></row>
```

I tried to open the file by LibreOffice. Everything good. A1 cell does not contains anything.

I saved the opened file to other file. The new file was successfully parsed.

The first row in the new file does not have A1 cell.
```
<row collapsed="false" customFormat="false" customHeight="true" hidden="false" ht="35" outlineLevel="0" r="1"><c r="B1" s="1" t="s"><v>0</v></c><c r="C1" s="1"/><c r="D1" s="1"/><c r="E1" s="1"/><c r="F1" s="1"/><c r="G1" s="1"/><c r="H1" s="1"/><c r="I1" s="1"/></row>
```

The fix helps.