### PR TITLE
Add ability to enter sheet properties

### DIFF
--- a/bits/67_wsxml.js
+++ b/bits/67_wsxml.js
@@ -63,6 +63,20 @@ function parse_ws_xml(data, opts, rels) {
 	return s;
 }
 
+function write_ws_xml_sheetpr(sheetpr) {
+	if(sheetpr.length == 0) return "";
+	var o = '<sheetPr>';
+	for(var i in sheetpr) {
+      for(var j in sheetpr[i]){
+        o += '<' + j;
+        for(var k in sheetpr[i][j])
+          o += ' ' + k + '="' + sheetpr[i][j][k] + '"';
+      o += '/>'
+      }
+  }
+	return o + '</sheetPr>';
+}
+
 function write_ws_xml_merges(merges) {
 	if(merges.length == 0) return "";
 	var o = '<mergeCells count="' + merges.length + '">';
@@ -304,8 +318,10 @@ function write_ws_xml(idx, opts, wb) {
 	var s = wb.SheetNames[idx], sidx = 0, rdata = "";
 	var ws = wb.Sheets[s];
 	if(ws === undefined) ws = {};
+	if(ws['!sheetPr'] !== undefined && ws['!sheetPr'].length > 0) o[o.length] = (write_ws_xml_sheetpr(ws['!sheetPr']));
 	var ref = ws['!ref']; if(ref === undefined) ref = 'A1';
 	o[o.length] = (writextag('dimension', null, {'ref': ref}));
+
 
   var sheetView = writextag('sheetView', null,  {
     showGridLines: opts.showGridLines == false ? '0' : '1',

--- a/bits/67_wsxml.js
+++ b/bits/67_wsxml.js
@@ -322,7 +322,6 @@ function write_ws_xml(idx, opts, wb) {
 	var ref = ws['!ref']; if(ref === undefined) ref = 'A1';
 	o[o.length] = (writextag('dimension', null, {'ref': ref}));
 
-
   var sheetView = writextag('sheetView', null,  {
     showGridLines: opts.showGridLines == false ? '0' : '1',
     tabSelected: opts.tabSelected === undefined ? '0' :  opts.tabSelected,

--- a/bits/67_wsxml.js
+++ b/bits/67_wsxml.js
@@ -67,12 +67,12 @@ function write_ws_xml_sheetpr(sheetpr) {
 	if(sheetpr.length == 0) return "";
 	var o = '<sheetPr>';
 	for(var i in sheetpr) {
-      for(var j in sheetpr[i]){
-        o += '<' + j;
-        for(var k in sheetpr[i][j])
-          o += ' ' + k + '="' + sheetpr[i][j][k] + '"';
+    for(var j in sheetpr[i]){
+      o += '<' + j;
+      for(var k in sheetpr[i][j])
+        o += ' ' + k + '="' + sheetpr[i][j][k] + '"';
       o += '/>'
-      }
+    }
   }
 	return o + '</sheetPr>';
 }


### PR DESCRIPTION
For my project I need the ability to color the tabs.  This is done in the sheetProperties class.

Please see:

https://msdn.microsoft.com/en-us/library/documentformat.openxml.spreadsheet.sheetproperties(v=office.14).aspx

For example to set a `sheet_name`s tab to blue: 

`workbook['Sheets'][sheet_name]['!sheetPr'] = [{tabColor: {theme: "3", tint: "-0.249977111117893"}}];`

