### PR TITLE
Allow quotePrefix option in styles.

### DIFF
--- a/xlsx.js
+++ b/xlsx.js
@@ -12359,6 +12359,10 @@ var XmlNode = (function () {
             .attr("borderId", borderId)
             .attr("xfId", "0");
 
+        if (attributes.quotePrefix > 0) {
+            $xf.attr("quotePrefix", "1");
+        }
+
         if (fontId > 0) {
           $xf.attr('applyFont', "1");
         }


### PR DESCRIPTION
This patch allows setting the quotePrefix attribute in the style so that Excel knows that the content of the cell edition box should be prefixed by an apostrophe. That way, the generated workbook does not mutate when such a cell is edited while keeping the same value. Try "42", "'42", "=42", "'=42", all of these should have quotePrefix style in order to make Excel happy/ier.